### PR TITLE
Disable Wrapping Lines

### DIFF
--- a/lua/default/basic.lua
+++ b/lua/default/basic.lua
@@ -7,6 +7,8 @@ vim.opt.syntax="Enable"
 vim.cmd[[
 highlight NvimTreeFolderIcon guibg=blue
 ]]
+--Disable wrapping line.
+vim.cmd[[set nowrap]]
 -- Disable transparent Background
 vim.opt.background = 'dark'
 -- Show current line number


### PR DESCRIPTION
It's really frustrating when NvPak config wraps lines as default Vim. It would be better to disable wrapping.