### PR TITLE
Fixing the dependency tree and neodev.nvim

### DIFF
--- a/lua/packages/lspconfig.lua
+++ b/lua/packages/lspconfig.lua
@@ -50,6 +50,7 @@ nvim_lsp.lua_ls.setup({
 				severity_sort = true, -- sort errors/warnings by severity
 				signs = true, -- add signs in the gutter for errors/warnings
 			},
+            workspace = { checkThirdParty = false },
 		},
 	},
 	capabilities = capabilities,

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -96,16 +96,22 @@ local opt = {
 
 local plugins = {
 	-- notification plugin
-    require("packages.nvim-notify"),
+	require("packages.nvim-notify"),
 	-- The goal of nvim-treesitter is both to provide a simple and easy way to use the interface for tree-sitter in Neovim and to provide some basic functionality such as highlighting based on it
-    require("packages.autocomplete.nvim-treesitter"),
+	require("packages.autocomplete.nvim-treesitter"),
 	-- lsp plugins
 	{
-		"neovim/nvim-lspconfig",
+		"williamboman/mason-lspconfig.nvim",
 		event = { "BufReadPre", "BufNew" },
 		dependencies = {
+			{
+				"folke/neodev.nvim",
+				config = function()
+					require("packages.neodev")
+				end,
+			},
 			"williamboman/mason.nvim",
-			"williamboman/mason-lspconfig.nvim",
+			"neovim/nvim-lspconfig",
 		},
 		config = function()
 			require("packages.lspconfig")
@@ -167,12 +173,6 @@ local plugins = {
 			require("packages.dap")
 		end,
 		ft = { "python", "rust", "lua" },
-	},
-	{
-		"folke/neodev.nvim",
-		config = function()
-			require("packages.neodev")
-		end,
 	},
 	-- vim diagnostics system
 	require("packages.lsp_lines"),


### PR DESCRIPTION
mason-lspconfig.nvim is a bridge and depends on both mason.nvim and nvim-lspconfig. So it must be higher in the dependency tree.

neodev.nvim must be loaded before nvim-lspconfig loads.

checkThirdParty must be disabled for fixing a pop-up that annoys the user:
Do you need to configure your work environment as "luv"?